### PR TITLE
Adding 'depth' option for extended urlencoded parsing

### DIFF
--- a/lib/types/urlencoded.js
+++ b/lib/types/urlencoded.js
@@ -100,6 +100,11 @@ function extendedparser(options) {
   var parameterLimit = options.parameterLimit !== undefined
     ? options.parameterLimit
     : 1000
+  
+  var depth = options.depth !== undefined
+    ? options.depth
+    : 5
+
   var parse = parser('qs')
 
   if (isNaN(parameterLimit) || parameterLimit < 1) {
@@ -120,10 +125,11 @@ function extendedparser(options) {
     }
 
     var arrayLimit = Math.max(100, paramCount)
-
+    
     return parse(body, {
       arrayLimit: arrayLimit,
-      parameterLimit: parameterLimit
+      parameterLimit: parameterLimit,
+      depth: depth
     })
   }
 }


### PR DESCRIPTION
When specifying the options for extended urlencoded parsing, this change allows a 'depth' option to be specified, which will override the default of 5 levels deep which qs uses to limit the expansion of foo[1][2][3][4][5][6][baz]. By default, baz would not be expanded. If a depth parameter is passed to the parser, it can be set to a high enough value that baz would be parsed and then be accessible as req.body.foo[1][2][3][4][5][6].baz instead of req.body.foo[1][2][3][4][5] == "[6][baz]".

Usage: 
`app.use(bodyParser.urlencoded({ extended: true, depth: 9 }));`
